### PR TITLE
Avoid compilation errors with libtirpc

### DIFF
--- a/daemon.c
+++ b/daemon.c
@@ -113,7 +113,8 @@ void logmsg(int prio, const char *fmt, ...)
  */
 struct in_addr get_remote(struct svc_req *rqstp)
 {
-    return (svc_getcaller(rqstp->rq_xprt))->sin_addr;
+    struct sockaddr_in *tptr=(struct sockaddr_in*)svc_getcaller(rqstp->rq_xprt);
+    return tptr->sin_addr;
 }
 
 /*
@@ -121,7 +122,8 @@ struct in_addr get_remote(struct svc_req *rqstp)
  */
 short get_port(struct svc_req *rqstp)
 {
-    return (svc_getcaller(rqstp->rq_xprt))->sin_port;
+    struct sockaddr_in *tptr=(struct sockaddr_in*)svc_getcaller(rqstp->rq_xprt);
+    return tptr->sin_port;
 }
 
 /*


### PR DESCRIPTION
This patch was initially reported on SourceForge
_Link:_ https://sourceforge.net/p/unfs3/bugs/8/
_Reporter:_ Paul Schutte 
_Created:_ 2016-11-08

---

libtirpc sets the structure to sockaddr_in6 which causes the following
compile errors:

> daemon.c: In function 'get_remote':
> daemon.c:113:43: error: 'struct sockaddr_in6' has no member named 'sin_addr'
> return (svc_getcaller(rqstp->rq_xprt))->sin_addr;
> ^
> daemon.c: In function 'get_port':
> daemon.c:121:43: error: 'struct sockaddr_in6' has no member named 'sin_port'
> return (svc_getcaller(rqstp->rq_xprt))->sin_port;

The answer is to cast it back from sockaddr_in6 to sockaddr_in as they
are suppose to be backward compatible.