### PR TITLE
Support building with libtirpc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,17 @@ AS_IF([test "x$LEX" == "x:"], [
 AC_PROG_YACC
 AC_HEADER_STDC
 AC_SYS_LARGEFILE
-AC_SEARCH_LIBS(xdr_int, nsl)
+AC_ARG_WITH([libtirpc],
+	    [AS_HELP_STRING([--with-libtirpc], [Use libtirpc RPC implementation])])
+
+AS_IF([test "x$with_libtirpc" != "xno"],
+      [PKG_CHECK_MODULES(TIRPC, libtirpc)
+       LIBS="$LIBS $TIRPC_LIBS"
+       CFLAGS="$CFLAGS $TIRPC_CFLAGS"
+       AC_DEFINE(HAVE_TIRPC,,[define if using libtirpc SunRPC implementation])],
+      [AC_CHECK_HEADER(rpc/rpc.h, [], AC_MSG_ERROR([SunRPC headers can't be found]))
+       AC_SEARCH_LIBS(xdr_init, nsl, [], AC_MSG_ERROR([SunRPC library can't be found]))])
+
 AC_SEARCH_LIBS(socket, socket)
 AC_SEARCH_LIBS(inet_aton, resolv)
 AC_CHECK_HEADERS(mntent.h,,,[#include <stdio.h>])

--- a/m4/unfs3-solaris-rpc.m4
+++ b/m4/unfs3-solaris-rpc.m4
@@ -1,6 +1,7 @@
 dnl Special rpc library for Solaris
 dnl
 AC_DEFUN([UNFS3_SOLARIS_RPC],[
+  AS_IF([test "x$with_libtirpc" = "xno"], [
   AC_CHECK_FUNC(svc_tli_create, [
     # On Solaris, you must link with librpcsoc, or the binaries won't work. 
     LDFLAGS="-L=/usr/ucblib -R/usr/ucblib $LDFLAGS"
@@ -8,5 +9,5 @@ AC_DEFUN([UNFS3_SOLARIS_RPC],[
         [ LIBS="-lrpcsoc $LIBS" ],
         [ AC_MSG_WARN([*** Cannot find librpcsoc. On Solaris, install package SUNWscpu. ***]) ]
     )
-  ])
+  ])])
 ])


### PR DESCRIPTION
With this patch I can build and run unfs3 on Linux systems with glibc 2.26 and newer (SunRPC code has been removed from glibc 2.26).
This patch is a bit simpler than #17, and it's possible to keep using glibc's RPC implementation on "old" systems.

Closes: #13