### PR TITLE
fix building on macOS

### DIFF
--- a/attr.c
+++ b/attr.c
@@ -18,6 +18,8 @@
 #include <utime.h>
 #include <errno.h>
 #include <dirent.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "backend.h"
 #include "nfs.h"


### PR DESCRIPTION
I had the following errors with Apple clang 13 (Xcode 13.4.1):

```
attr.c:560:5: error: implicitly declaring library function 'free' with type 'void (void *)' [-Werror,-Wimplicit-function-declaration]
    free(bad_dir_cache[best].path);
    ^
attr.c:560:5: note: include the header <stdlib.h> or explicitly provide a declaration for 'free'
bison -y -d ./exports.y
attr.c:577:6: error: implicitly declaring library function 'strcmp' with type 'int (const char *, const char *)' [-Werror,-Wimplicit-function-declaration]
        if (strcmp(path, bad_dir_cache[i].path) == 0) {
            ^
attr.c:577:6: note: include the header <string.h> or explicitly provide a declaration for 'strcmp'
attr.c:585:23: error: implicitly declaring library function 'strdup' with type 'char *(const char *)' [-Werror,-Wimplicit-function-declaration]
    new_entry->path = strdup(path);
                      ^
attr.c:585:23: note: include the header <string.h> or explicitly provide a declaration for 'strdup'
```