### PR TITLE
Alias off64_t to off_t on linux if not defined

### DIFF
--- a/nfs.h
+++ b/nfs.h
@@ -62,7 +62,7 @@ typedef int32_t int32;
 #endif
 
 #ifndef HAVE_OFF64_T
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__linux__)
 typedef off_t off64_t;
 #endif
 #endif


### PR DESCRIPTION
Musl C library does not define off64_t and has 64-bit default off_t therefore define off64_t as an alias on linux as well when configure detects that off64_t is not provided by a linux system

Signed-off-by: Khem Raj <raj.khem@gmail.com>