### PR TITLE
locate.c: Include attr.h

### DIFF
--- a/locate.c
+++ b/locate.c
@@ -27,6 +27,7 @@
 #include "nfs.h"
 #include "fh.h"
 #include "daemon.h"
+#include "attr.h"
 
 /*
  * these are the brute-force file searching routines that are used


### PR DESCRIPTION
Its needed for fix_dir_times() API declarations

Signed-off-by: Khem Raj <raj.khem@gmail.com>