### PR TITLE
attr: fix utime for symlink

### DIFF
--- a/backend_unix.h
+++ b/backend_unix.h
@@ -61,6 +61,8 @@
 #define backend_symlink symlink
 #define backend_truncate truncate
 #define backend_utime utime
+#define backend_utimes utimes
+#define backend_lutimes lutimes
 #define backend_statstruct struct stat
 #define backend_dirstream DIR
 #define backend_statvfsstruct struct statvfs

--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,7 @@ AC_CHECK_FUNCS(setresuid setresgid)
 AC_CHECK_FUNCS(vsyslog)
 AC_CHECK_FUNCS(lchown)
 AC_CHECK_FUNCS(setgroups)
+AC_CHECK_FUNCS(lutimes)
 UNFS3_COMPILE_WARNINGS
 
 PKG_CHECK_MODULES([TIRPC], [libtirpc])


### PR DESCRIPTION
unfs3 has an old defect that it can not change the timestamps of a symlink file because it only uses utime(), which will follow the symlink. This will not cause an error if the symlink points to an existent file. But under some special situation, such as installing a rpm package, rpm tool will create the symlink first and try to modify the timestamps of it, when the target file is non-existent. This will cause an ESTALE error. Making rpm tool ignore this error is a solution, but not the best one. An acceptable approach is Making unfs3 support lutimes(), which can modify the symlink file itself. Considering not every system support this function, so a function checking is necessary.