### PR TITLE
32 bit client support

### DIFF
--- a/attr.c
+++ b/attr.c
@@ -199,17 +199,19 @@ post_op_attr get_post_buf(backend_statstruct buf, struct svc_req * req)
        dev_t is signed, such as 32-bit OS X. */
     result.post_op_attr_u.attributes.fsid &= 0xFFFFFFFF;
 
-#if defined(WIN32) || defined(AFS_SUPPORT)
-    /* Recent Linux kernels (2.6.24 and newer) expose large fileids even to
-       non-LFS 32-bit applications, unless kernel parameter
-       nfs.enable_ino64=0. This means that applications will fail with
-       EOVERFLOW. On Windows, we always have large st_ino:s. To avoid
-       trouble, we truncate to 32 bits */
-    result.post_op_attr_u.attributes.fileid =
-	(buf.st_ino >> 32) ^ (buf.st_ino & 0xffffffff);
-#else
-    result.post_op_attr_u.attributes.fileid = buf.st_ino;
-#endif
+    if(opt_32_bit_truncate) {
+     /* Recent Linux kernels (2.6.24 and newer) expose large fileids even to
+        non-LFS 32-bit applications, unless kernel parameter
+        nfs.enable_ino64=0. This means that applications will fail with
+        EOVERFLOW. On Windows, we always have large st_ino:s. To avoid
+        trouble, we truncate to 32 bits */
+      result.post_op_attr_u.attributes.fileid =
+        (buf.st_ino >> 32) ^ (buf.st_ino & 0xffffffff);
+    }
+    else {
+      result.post_op_attr_u.attributes.fileid = buf.st_ino;
+    }
+
     result.post_op_attr_u.attributes.atime.seconds = buf.st_atime;
     result.post_op_attr_u.attributes.atime.nseconds = 0;
     result.post_op_attr_u.attributes.mtime.seconds = buf.st_mtime;

--- a/daemon.c
+++ b/daemon.c
@@ -77,6 +77,7 @@ int opt_testconfig = FALSE;
 struct in6_addr opt_bind_addr;
 int opt_readable_executables = FALSE;
 char *opt_pid_file = NULL;
+int opt_32_bit_truncate = FALSE;
 
 /* Register with portmapper? */
 int opt_portmapper = TRUE;
@@ -219,13 +220,20 @@ static void remove_pid_file(void)
  */
 static void parse_options(int argc, char **argv)
 {
-
     int opt = 0;
-    char *optstring = "bcC:de:hl:m:n:prstTuwi:";
+    char *optstring = "3bcC:de:hl:m:n:prstTuwi:";
+
+#if defined(WIN32) || defined(AFS_SUPPORT)
+     /* Allways truncate to 32 bits in these cases */
+    opt_32_bit_truncate = TRUE;
+#endif
 
     while (opt != -1) {
 	opt = getopt(argc, argv, optstring);
 	switch (opt) {
+	    case '3':
+		opt_32_bit_truncate = TRUE;
+		break;
 	    case 'b':
 		opt_brute_force = TRUE;
 		break;
@@ -275,6 +283,8 @@ static void parse_options(int argc, char **argv)
 		    ("\t-l <addr>   bind to interface with specified address\n");
 		printf
 		    ("\t-r          report unreadable executables as readable\n");
+		printf
+		    ("\t-3          truncate fileid and cookie to 32 bits\n");
 		printf("\t-T          test exports file and exit\n");
 		exit(0);
 		break;

--- a/daemon.c
+++ b/daemon.c
@@ -1062,9 +1062,17 @@ void regenerate_write_verifier(void)
  */
 void change_readdir_cookie(void)
 {
-    rcookie = rcookie >> 32;
-    ++rcookie;
-    rcookie = rcookie << 32;
+    if(opt_32_bit_truncate) {
+        rcookie = rcookie >> 20;
+        ++rcookie;
+        rcookie &= 0xFFF;
+        rcookie = rcookie << 20;
+    }
+    else {
+        rcookie = rcookie >> 32;
+        ++rcookie;
+        rcookie = rcookie << 32;
+    }
 }
 
 /*

--- a/daemon.h
+++ b/daemon.h
@@ -45,5 +45,6 @@ extern char	*opt_cluster_path;
 extern int	opt_singleuser;
 extern int	opt_brute_force;
 extern int	opt_readable_executables;
+extern int      opt_32_bit_truncate;
 
 #endif

--- a/readdir.c
+++ b/readdir.c
@@ -148,12 +148,15 @@ READDIR3res read_dir(const char *path, cookie3 cookie, cookieverf3 verf,
 
 	    strcpy(&obj[i * NFS_MAXPATHLEN], this->d_name);
 
-#if defined(WIN32) || defined(AFS_SUPPORT)
-	    /* See comment in attr.c:get_post_buf */
-	    entry[i].fileid = (buf.st_ino >> 32) ^ (buf.st_ino & 0xffffffff);
-#else
-	    entry[i].fileid = buf.st_ino;
-#endif
+            if(opt_32_bit_truncate) {
+                /* See comment in attr.c:get_post_buf */
+                entry[i].fileid =
+                    (buf.st_ino >> 32) ^ (buf.st_ino & 0xffffffff);
+            }
+            else {
+                entry[i].fileid = buf.st_ino;
+            }
+
 	    entry[i].name = &obj[i * NFS_MAXPATHLEN];
 	    entry[i].cookie = (cookie + 1 + i) | rcookie;
 	    entry[i].nextentry = NULL;

--- a/readdir.c
+++ b/readdir.c
@@ -77,12 +77,22 @@ READDIR3res read_dir(const char *path, cookie3 cookie, cookieverf3 verf,
     char scratch[NFS_MAXPATHLEN];
 
     /* check upper part of cookie */
-    upper = cookie & 0xFFFFFFFF00000000ULL;
+    if(opt_32_bit_truncate) {
+      upper = cookie & 0xFFF00000ULL;
+    }
+    else {
+      upper = cookie & 0xFFFFFFFF00000000ULL;
+    }
     if (cookie != 0 && upper != rcookie) {
       /* ignore cookie if unexpected so we restart from the beginning */
       cookie = 0;
     }
-    cookie &= 0xFFFFFFFFULL;
+    if(opt_32_bit_truncate) {
+      cookie &= 0xFFFFFULL;
+    }
+    else {
+      cookie &= 0xFFFFFFFFULL;
+    }
 
     /* we refuse to return more than 4k from READDIR */
     if (count > 4096)

--- a/unfsd.8
+++ b/unfsd.8
@@ -175,6 +175,10 @@ requests for unreadable executables are always allowed, if
 .B unfsd 
 is running as root, regardless of this option.
 .TP
+.B \-3
+Truncate fileid and cookie to 32 bits, this might be required by some 32 bit
+applications on older NFS clients which otherwise might fail with EOVERFLOW.
+.TP
 .B \-T
 Test exports file and exit. When this option is given,
 .B unfsd


### PR DESCRIPTION
Adding switch -3 to allow limiting fileid and cookie to 32 bits for compability with some old 32-bit applications on clients.