### PR TITLE
make it possible to create a backend which has its own dirent structure

### DIFF
--- a/attr.c
+++ b/attr.c
@@ -522,7 +522,7 @@ nfsstat3 atomic_attr(sattr3 attr)
 static uint32 directory_hash(const char *path)
 {
     backend_dirstream *search;
-    struct dirent *this;
+    backend_dirent *this;
     uint32 hval = 0;
 
     search = backend_opendir(path);

--- a/backend_unix.h
+++ b/backend_unix.h
@@ -63,6 +63,7 @@
 #define backend_utimes utimes
 #define backend_lutimes lutimes
 #define backend_statstruct struct stat
+#define backend_dirent struct dirent
 #define backend_dirstream DIR
 #define backend_statvfsstruct struct statvfs
 #define backend_fsinfo_properties FSF3_LINK | FSF3_SYMLINK | FSF3_HOMOGENEOUS | FSF3_CANSETTIME;

--- a/backend_win32.h
+++ b/backend_win32.h
@@ -64,6 +64,7 @@
 #define backend_truncate win_truncate
 #define backend_utimes win_utimes
 #define backend_init win_init
+#define backend_dirent struct dirent
 #define backend_dirstream UNFS3_WIN_DIR
 #define backend_fsinfo_properties FSF3_HOMOGENEOUS | FSF3_CANSETTIME;
 /*

--- a/fh.c
+++ b/fh.c
@@ -376,7 +376,7 @@ static int fh_rec(const unfs3_fh_t * fh, int pos, const char *lead,
 		  char *result)
 {
     backend_dirstream *search;
-    struct dirent *entry;
+    backend_dirent *entry;
     backend_statstruct buf;
     int res, rec;
     char obj[NFS_MAXPATHLEN];

--- a/readdir.c
+++ b/readdir.c
@@ -71,7 +71,7 @@ READDIR3res read_dir(const char *path, cookie3 cookie, cookieverf3 verf,
     backend_statstruct buf;
     int res;
     backend_dirstream *search;
-    struct dirent *this;
+    backend_dirent *this;
     count3 i, real_count;
     static char obj[NFS_MAXPATHLEN * MAX_ENTRIES];
     char scratch[NFS_MAXPATHLEN];


### PR DESCRIPTION
this also avoids an unneeded lstat() in the readdir loop that is only needed when AFS_SUPPORT is defined (because in that case we use private inode numbers instead of the ones in the dirent)