### PR TITLE
Don't link unfsd with Flex's libfl

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -12,7 +12,7 @@ OBJS = afsgettimes.o afssupport.o attr.o daemon.o error.o fd_cache.o fh.o fh_cac
        md5.o mount.o nfs.o password.o readdir.o user.o xdr.o winsupport.o
 CONFOBJ = Config/lib.a
 EXTRAOBJ = @EXTRAOBJ@
-LDFLAGS = @LDFLAGS@ @LIBS@ @LEXLIB@ @AFS_LIBS@ @TIRPC_LIBS@
+LDFLAGS = @LDFLAGS@ @LIBS@ @AFS_LIBS@ @TIRPC_LIBS@
 EXEEXT = @EXEEXT@
 
 srcdir = @srcdir@


### PR DESCRIPTION
In commit 3fa0568 we removed the dependency on yywrap() which is a part of Flex, which means that we no longer need libfl when linking.