### PR TITLE
Fix call to getsockopt with incompatible pointers

### DIFF
--- a/daemon.c
+++ b/daemon.c
@@ -695,7 +695,7 @@ static int
 _socket_getdomain(int socket, int *domain, socklen_t *len)
 {
 #ifdef SO_DOMAIN
-    return getsockopt(socket, SOL_SOCKET, SO_DOMAIN, &domain, &len);
+    return getsockopt(socket, SOL_SOCKET, SO_DOMAIN, domain, len);
 #elif defined(PROC_PIDFDSOCKETINFO)
     struct socket_fdinfo info;
     int ret;


### PR DESCRIPTION
The last two arguments to the `_socket_getdomain()` are already pointers, we shouldn't reference them a second time when calling `getsockopt()`.

I got a build error when building on Fedora 41:
```
daemon.c: In function ‘_socket_getdomain’:
daemon.c:698:63: error: passing argument 5 of ‘getsockopt’ from incompatible pointer type [-Wincompatible-pointer-types]
  698 |     return getsockopt(socket, SOL_SOCKET, SO_DOMAIN, &domain, &len);
      |                                                               ^~~~
      |                                                               |
      |                                                               socklen_t ** {aka unsigned int **}
In file included from /usr/include/tirpc/rpc/rpc.h:39,
                 from daemon.c:14:
/usr/include/sys/socket.h:257:46: note: expected ‘socklen_t * restrict’ {aka ‘unsigned int * restrict’} but argument is of type ‘socklen_t **’ {aka ‘unsigned int **’}
  257 |                        socklen_t *__restrict __optlen) __THROW;
      |                        ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
make: *** [<builtin>: daemon.o] Error 1

```

Looks like there was a mistake made when adding the wrapper function in commit d495c74d.